### PR TITLE
[src] Release 1.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
 
 script:
 - make test
+- if [ $TRAVIS_REPO_SLUG != "terraform-providers/terraform-provider-spotinst" ]; then make testacc spotinst; fi
 - make vendor-status
 - make vet
 - make website-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ install:
 
 script:
 - make test
-- make testacc spotinst
 - make vendor-status
 - make vet
 - make website-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.6.0 (Unreleased)
+## 1.6.0 (January 18, 2019)
 
 NOTES:
 * resource/spotinst_elastigroup_azure: Added a new spotinst_elastigroup_azure resource for creating Spotinst elastigroups using Microsoft Azure


### PR DESCRIPTION
## 1.6.0 (January 18, 2019)

NOTES:
* resource/spotinst_elastigroup_azure: Added a new spotinst_elastigroup_azure resource for creating Spotinst elastigroups using Microsoft Azure
* resource/spotinst_elastigroup_gcp: Added a new spotinst_elastigroup_gcp resource for creating Spotinst elastigroups using Google Cloud
* resource/spotinst_elastigroup_gke: Added a new spotinst_elastigroup_gke resource for creating Spotinst elastigroups using Google Kubernetes Engine
* resource/spotinst_ocean_aws: Added a new spotinst_ocean_aws resource for creating Spotinst Ocean clusters on AWS

FEATURES:

* *New Resource*: `spotinst_elastigroup_azure`
* *New Resource*: `spotinst_elastigroup_gcp`
* *New Resource*: `spotinst_elastigroup_gke`
* *New Resource*: `spotinst_ocean_aws`