### PR TITLE
Conditionally base64-decode fields that also have conditional encoding

### DIFF
--- a/spotinst/elastigroup_aws_launch_configuration/fields_spotinst_elastigroup_launch_configuration.go
+++ b/spotinst/elastigroup_aws_launch_configuration/fields_spotinst_elastigroup_launch_configuration.go
@@ -229,7 +229,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 				userData := elastigroup.Compute.LaunchSpecification.UserData
 				userDataValue := spotinst.StringValue(userData)
 				if userDataValue != "" {
-					value = string(userDataValue)
+					value = userDataValue
 				}
 			}
 			if err := resourceData.Set(string(UserData), HexStateFunc(value)); err != nil {

--- a/spotinst/elastigroup_aws_launch_configuration/fields_spotinst_elastigroup_launch_configuration.go
+++ b/spotinst/elastigroup_aws_launch_configuration/fields_spotinst_elastigroup_launch_configuration.go
@@ -227,10 +227,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 				elastigroup.Compute.LaunchSpecification.UserData != nil {
 
 				userData := elastigroup.Compute.LaunchSpecification.UserData
-				userDataValue := spotinst.StringValue(userData)
-				if userDataValue != "" {
-					value = userDataValue
-				}
+				value = spotinst.StringValue(userData)
 			}
 			if err := resourceData.Set(string(UserData), HexStateFunc(value)); err != nil {
 				return fmt.Errorf(string(commons.FailureFieldReadPattern), string(UserData), err)

--- a/spotinst/elastigroup_aws_launch_configuration/fields_spotinst_elastigroup_launch_configuration.go
+++ b/spotinst/elastigroup_aws_launch_configuration/fields_spotinst_elastigroup_launch_configuration.go
@@ -229,7 +229,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 				userData := elastigroup.Compute.LaunchSpecification.UserData
 				userDataValue := spotinst.StringValue(userData)
 				if userDataValue != "" {
-					value = userDataValue
+					value = string(userDataValue)
 				}
 			}
 			if err := resourceData.Set(string(UserData), HexStateFunc(value)); err != nil {

--- a/spotinst/elastigroup_aws_launch_configuration/fields_spotinst_elastigroup_launch_configuration.go
+++ b/spotinst/elastigroup_aws_launch_configuration/fields_spotinst_elastigroup_launch_configuration.go
@@ -227,7 +227,10 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 				elastigroup.Compute.LaunchSpecification.UserData != nil {
 
 				userData := elastigroup.Compute.LaunchSpecification.UserData
-				value = spotinst.StringValue(userData)
+				userDataValue := spotinst.StringValue(userData)
+				if userDataValue != "" {
+					value = userDataValue
+				}
 			}
 			if err := resourceData.Set(string(UserData), HexStateFunc(value)); err != nil {
 				return fmt.Errorf(string(commons.FailureFieldReadPattern), string(UserData), err)

--- a/spotinst/elastigroup_aws_launch_configuration/fields_spotinst_elastigroup_launch_configuration.go
+++ b/spotinst/elastigroup_aws_launch_configuration/fields_spotinst_elastigroup_launch_configuration.go
@@ -229,8 +229,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 				userData := elastigroup.Compute.LaunchSpecification.UserData
 				userDataValue := spotinst.StringValue(userData)
 				if userDataValue != "" {
-					decodedUserData, _ := base64.StdEncoding.DecodeString(userDataValue)
-					value = string(decodedUserData)
+					value = string(userDataValue)
 				}
 			}
 			if err := resourceData.Set(string(UserData), HexStateFunc(value)); err != nil {

--- a/spotinst/elastigroup_aws_launch_configuration/fields_spotinst_elastigroup_launch_configuration.go
+++ b/spotinst/elastigroup_aws_launch_configuration/fields_spotinst_elastigroup_launch_configuration.go
@@ -229,8 +229,12 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 				userData := elastigroup.Compute.LaunchSpecification.UserData
 				userDataValue := spotinst.StringValue(userData)
 				if userDataValue != "" {
-					decodedUserData, _ := base64.StdEncoding.DecodeString(userDataValue)
-					value = string(decodedUserData)
+					if isBase64Encoded(resourceData.Get(string(UserData)).(string)) {
+						value = userDataValue
+					} else {
+						decodedUserData, _ := base64.StdEncoding.DecodeString(userDataValue)
+						value = string(decodedUserData)
+					}
 				}
 			}
 			if err := resourceData.Set(string(UserData), HexStateFunc(value)); err != nil {
@@ -287,8 +291,12 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 				shutdownScript := elastigroup.Compute.LaunchSpecification.ShutdownScript
 				shutdownScriptValue := spotinst.StringValue(shutdownScript)
 				if shutdownScriptValue != "" {
-					decodedShutdownScript, _ := base64.StdEncoding.DecodeString(shutdownScriptValue)
-					value = string(decodedShutdownScript)
+					if isBase64Encoded(resourceData.Get(string(ShutdownScript)).(string)) {
+						value = shutdownScriptValue
+					} else {
+						decodedShutdownScript, _ := base64.StdEncoding.DecodeString(shutdownScriptValue)
+						value = string(decodedShutdownScript)
+					}
 				}
 			}
 			if err := resourceData.Set(string(ShutdownScript), HexStateFunc(value)); err != nil {

--- a/spotinst/elastigroup_aws_launch_configuration/fields_spotinst_elastigroup_launch_configuration.go
+++ b/spotinst/elastigroup_aws_launch_configuration/fields_spotinst_elastigroup_launch_configuration.go
@@ -229,7 +229,8 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 				userData := elastigroup.Compute.LaunchSpecification.UserData
 				userDataValue := spotinst.StringValue(userData)
 				if userDataValue != "" {
-					value = string(userDataValue)
+					decodedUserData, _ := base64.StdEncoding.DecodeString(userDataValue)
+					value = string(decodedUserData)
 				}
 			}
 			if err := resourceData.Set(string(UserData), HexStateFunc(value)); err != nil {

--- a/spotinst/elastigroup_azure_launch_configuration/fields_spotinst_elastigroup_azure_launch_configuration.go
+++ b/spotinst/elastigroup_azure_launch_configuration/fields_spotinst_elastigroup_azure_launch_configuration.go
@@ -40,8 +40,12 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 				userData := elastigroup.Compute.LaunchSpecification.UserData
 				userDataValue := spotinst.StringValue(userData)
 				if userDataValue != "" {
-					decodedUserData, _ := base64.StdEncoding.DecodeString(userDataValue)
-					value = string(decodedUserData)
+					if isBase64Encoded(resourceData.Get(string(UserData)).(string)) {
+						value = userDataValue
+					} else {
+						decodedUserData, _ := base64.StdEncoding.DecodeString(userDataValue)
+						value = string(decodedUserData)
+					}
 				}
 			}
 			if err := resourceData.Set(string(UserData), HexStateFunc(value)); err != nil {

--- a/spotinst/elastigroup_gcp_launch_configuration/fields_spotinst_elastigroup_gcp_launch_configuration.go
+++ b/spotinst/elastigroup_gcp_launch_configuration/fields_spotinst_elastigroup_gcp_launch_configuration.go
@@ -312,8 +312,12 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 				startupScript := elastigroup.Compute.LaunchSpecification.StartupScript
 				startupScriptValue := spotinst.StringValue(startupScript)
 				if startupScriptValue != "" {
-					decodedStartupScript, _ := base64.StdEncoding.DecodeString(startupScriptValue)
-					value = string(decodedStartupScript)
+					if isBase64Encoded(resourceData.Get(string(StartupScript)).(string)) {
+						value = startupScriptValue
+					} else {
+						decodedStartupScript, _ := base64.StdEncoding.DecodeString(startupScriptValue)
+						value = string(decodedStartupScript)
+					}
 				}
 			}
 			if err := resourceData.Set(string(StartupScript), HexStateFunc(value)); err != nil {

--- a/spotinst/ocean_aws_launch_configuration/fields_spotinst_ocean_aws_launch_configuration.go
+++ b/spotinst/ocean_aws_launch_configuration/fields_spotinst_ocean_aws_launch_configuration.go
@@ -230,8 +230,12 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 				userData := cluster.Compute.LaunchSpecification.UserData
 				userDataValue := spotinst.StringValue(userData)
 				if userDataValue != "" {
-					decodedUserData, _ := base64.StdEncoding.DecodeString(userDataValue)
-					value = string(decodedUserData)
+					if isBase64Encoded(resourceData.Get(string(UserData)).(string)) {
+						value = userDataValue
+					} else {
+						decodedUserData, _ := base64.StdEncoding.DecodeString(userDataValue)
+						value = string(decodedUserData)
+					}
 				}
 			}
 			if err := resourceData.Set(string(UserData), HexStateFunc(value)); err != nil {


### PR DESCRIPTION
Doing so will always cause a drift since the local state is base64-encoded.
This may very well be an issue with other cloud providers and/or resources as well, this is just the only one where we ran into the issue of this incosistent base64 encoding.